### PR TITLE
fixed formatting + clippy warnings

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -3,7 +3,7 @@ use think;
 pub static mut chocolate : [u8; 64] = [0; 64];
 pub const full_board_size: usize = 120;
 pub const playable_size: usize = 64;
-pub const void_square: u8 = 100; 
+pub const void_square: u8 = 100;
 pub const max_game_length: usize = 1024;
 pub const white: bool = false;
 pub const black: bool = true;
@@ -52,7 +52,7 @@ pub enum castling_bits {
     k_cp = 1 << 2,
     q_cp = 1 << 3
 }
-    
+
 
 pub enum square {
     A1 = 21, B1, C1, D1, E1, F1, G1, H1,
@@ -131,24 +131,24 @@ pub fn init() -> (chessboard) {
         past: unsafe { mem::zeroed() },
         transposition_table: think::transposition_table::new(),
         zobrist: 0
-    }; 
+    };
 
     reset(&mut new_board);
 
-    return new_board;
+    new_board
 }
 
 pub fn reset (board: &mut chessboard) {
     use std::mem;
     use zobrist;
 
-    for i in 0..full_board_size {
-        board.layout[i] = void_square;
+    for mut l in &mut board.layout[0..full_board_size] {
+        *l = void_square;
     }
 
-    for i in 0..playable_size {
-        unsafe {
-            board.layout[chocolate[i] as usize] = piece::Empty as u8;
+    unsafe {
+        for c in &chocolate[..playable_size] {
+            board.layout[*c as usize] = piece::Empty as u8;
         }
     }
 
@@ -162,7 +162,7 @@ pub fn reset (board: &mut chessboard) {
 
     board.score = [0; 2];
 
-    board.castling = castling_bits::K_cp as u8 | castling_bits::Q_cp as u8 
+    board.castling = castling_bits::K_cp as u8 | castling_bits::Q_cp as u8
         | castling_bits::k_cp as u8 | castling_bits::q_cp as u8;
 
     board.en_passant = void_square;
@@ -175,8 +175,8 @@ pub fn reset (board: &mut chessboard) {
 }
 
 pub fn AN_to_chocolate (file : char, rank : u8) -> (u8) {
-    let rank_index = rank - '1' as u8;
-    let file_index = file as u8 - 'a' as u8;
+    let rank_index = rank - b'1';
+    let file_index = file as u8 - b'a';
 
     (rank_index + 2) * 10 + file_index + 1
 }
@@ -187,19 +187,18 @@ pub fn AN_to_board (file : u8, rank : u8) -> (u8) {
 
 pub fn to_AN(square : u8) -> [char; 2] {
     let mut answer : [char; 2] = ['0'; 2];
-    answer[0] = ('a' as u8 + (square % 10 - 1)) as char;
-    answer[1] = ('1' as u8 + (square / 10 - 2)) as char;
+    answer[0] = (b'a' + (square % 10 - 1)) as char;
+    answer[1] = (b'1' + (square / 10 - 2)) as char;
     answer
 }
 
 pub fn update_pieces (cboard: &mut chessboard) {
-    for i in 0..playable_size {
-        unsafe {
-            let index = chocolate[i];
-            let piece = cboard.layout[index as usize];
+    unsafe {
+        for index in &chocolate[..playable_size] {
+            let piece = cboard.layout[*index as usize];
 
             if piece != piece::Empty as u8 {
-                cboard.piece_list[piece as usize][cboard.piece_count[piece as usize] as usize] = index;
+                cboard.piece_list[piece as usize][cboard.piece_count[piece as usize] as usize] = *index;
                 cboard.piece_count[piece as usize] += 1;
                 if piece < 7 {
                     // white
@@ -230,5 +229,5 @@ pub fn print (cboard: &chessboard) {
     println!("white king: {}, black king: {}", cboard.piece_list[piece::K as usize][0], cboard.piece_list[piece::k as usize][0]);
     println!("1 white rook: {}, 2 white rook: {}", cboard.piece_list[piece::R as usize][0], cboard.piece_list[piece::R as usize][1]);
     println!("\nHash: {}", cboard.zobrist);
-    print!("\n");
+    println!();
 }

--- a/src/fen.rs
+++ b/src/fen.rs
@@ -42,7 +42,7 @@ pub fn parse(fen : &str, cboard: &mut board::chessboard) {
 
         if empty != 0 {
             let start = board::AN_to_board(file, rank) as usize;
-            empty = empty - ('0' as u8);
+            empty -= b'0';
 
             for i in 0..empty {
                 cboard.layout[start + i as usize] = piece::Empty as u8;
@@ -51,7 +51,7 @@ pub fn parse(fen : &str, cboard: &mut board::chessboard) {
             file += empty;
         }
 
-        counter += 1; 
+        counter += 1;
     }
     counter += 1;
 
@@ -90,11 +90,11 @@ pub fn parse(fen : &str, cboard: &mut board::chessboard) {
     counter += 1;
 
     // fifty move parsing
-    if fen[counter + 1] as char == ' ' {
-        cboard.fifty = fen[counter] - '0' as u8;
+    if fen[counter + 1] == b' ' {
+        cboard.fifty = fen[counter] - b'0';
         counter +=1;
-    } else if fen[counter + 2] as char == ' ' {
-        cboard.fifty = (fen[counter] - '0' as u8) * 10 + fen[counter + 1] - '0' as u8;
+    } else if fen[counter + 2] == b' ' {
+        cboard.fifty = (fen[counter] - b'0') * 10 + fen[counter + 1] - b'0';
         counter +=2;
     } else {
         panic!("[!] Critical: Invalid FEN fifty move code");
@@ -103,7 +103,7 @@ pub fn parse(fen : &str, cboard: &mut board::chessboard) {
 
     // game depth parsing
     if counter + 3 == fen.len() {
-        cboard.depth = (fen[counter] as u16 - '0' as u16) * 100 + (fen[counter + 1] as u16 - '0' as u16) 
+        cboard.depth = (fen[counter] as u16 - '0' as u16) * 100 + (fen[counter + 1] as u16 - '0' as u16)
             * 10 + fen[counter + 2] as u16 - '0' as u16;
     } else if counter + 2 == fen.len() {
         cboard.depth = (fen[counter] as u16 - '0' as u16) * 10 + fen[counter + 1] as u16 - '0' as u16;
@@ -115,5 +115,5 @@ pub fn parse(fen : &str, cboard: &mut board::chessboard) {
     board::update_pieces(cboard);
 
     // hash update
-    cboard.zobrist = zobrist::hash(cboard); 
+    cboard.zobrist = zobrist::hash(cboard);
 }

--- a/src/movement.rs
+++ b/src/movement.rs
@@ -19,7 +19,7 @@ pub fn make(m : &moves::_move, cboard : &mut board::chessboard) -> bool {
     cboard.past[cboard.depth as usize] = snapshot;
 
     cboard.fifty += 1;
-    
+
     // unhash all the things
     zobrist::castle(cboard);
     zobrist::en_passant(cboard);
@@ -41,7 +41,7 @@ pub fn make(m : &moves::_move, cboard : &mut board::chessboard) -> bool {
             93  => square::plsmove(91, 94, cboard), // black queenside
             _ => {panic!("invalid castling");}
         }
-    } 
+    }
 
     if cboard.layout[origin as usize] == board::piece::P as u8 ||
                     cboard.layout[origin as usize] == board::piece::p as u8{
@@ -102,16 +102,11 @@ pub fn make(m : &moves::_move, cboard : &mut board::chessboard) -> bool {
 
     debug_assert!(sanity::sane(cboard));
 
-    if cboard.side == board::black {
-        if square::attacked(cboard.piece_list[board::piece::K as usize][0], board::black, cboard) {
-            undo(cboard);
-            return false;
-        }
-    } else {
-        if square::attacked(cboard.piece_list[board::piece::k as usize][0], board::white, cboard) {
-            undo(cboard);
-            return false;
-        }
+    if square::attacked(cboard.piece_list[if cboard.side == board::black {
+            board::piece::K } else { board::piece::k } as usize][0],
+            cboard.side, cboard) {
+        undo(cboard);
+        return false;
     }
     true
 }
@@ -151,7 +146,7 @@ pub fn undo(cboard : &mut board::chessboard) {
             93  => square::plsmove(94, 91, cboard), // black queenside
             _ => unreachable!()
         }
-    } 
+    }
 
     square::plsmove(target, origin, cboard);
 

--- a/src/moves.rs
+++ b/src/moves.rs
@@ -3,7 +3,7 @@ use square;
 
 const max_moves : usize = 256;
 const around : [i8; 2] = [1, -1];
-const MVV : [u16; 13] = [0, 0, 5000, 4000, 3000, 2000, 1000, 0, 5000, 4000, 3000, 2000, 1000]; 
+const MVV : [u16; 13] = [0, 0, 5000, 4000, 3000, 2000, 1000, 0, 5000, 4000, 3000, 2000, 1000];
 const AN_pieces: [char; 13] = ['x', 'k', 'q', 'r', 'b', 'n', 'p', 'k', 'q', 'r', 'b', 'n', 'p'];
 
 pub struct _move {
@@ -20,7 +20,7 @@ impl _move {
         combined |= from as u32;
         combined |= (to as u32) << 7;
         combined |= (captured as u32) << 14;
-        combined |= (promoted as u32) << 18; 
+        combined |= (promoted as u32) << 18;
         combined |= (en_passant as u32) << 22;
         combined |= (pawn_double as u32) << 23;
         combined |= (castling as u32) << 24;
@@ -99,8 +99,8 @@ pub fn from_AN(move_str : &[u8], cboard : &board::chessboard) -> _move{
     let mut move_list : movelist =  movelist::new();
     generator(&mut move_list, cboard);
 
-    let from_sq = board::AN_to_board(move_str[0] - 'a' as u8, move_str[1] - '1' as u8);
-    let to_sq   = board::AN_to_board(move_str[2] - 'a' as u8, move_str[3] - '1' as u8);
+    let from_sq = board::AN_to_board(move_str[0] - b'a', move_str[1] - b'1');
+    let to_sq   = board::AN_to_board(move_str[2] - b'a', move_str[3] - b'1');
     let mut prom : u8 = 0;
 
     if move_str.len() == 5 {
@@ -124,8 +124,8 @@ pub fn from_AN(move_str : &[u8], cboard : &board::chessboard) -> _move{
     }
 
     for x in 0..move_list.count as usize {
-        let ref result = move_list.all[x];
-        if to(&result) == to_sq && from(&result) == from_sq && promoted(&result) == prom {
+        let result = &move_list.all[x];
+        if to(result) == to_sq && from(result) == from_sq && promoted(result) == prom {
             return _move{container: result.container, score : 0}
         }
     }
@@ -133,10 +133,7 @@ pub fn from_AN(move_str : &[u8], cboard : &board::chessboard) -> _move{
 }
 
 pub fn generator(list : &mut movelist, cboard : &board::chessboard) {
-    let mut baseline : usize = 0;
-    if cboard.side == board::black {
-        baseline = 6;
-    }
+    let baseline = if cboard.side == board::black { 6 } else { 0 };
 
     for x in (1 + baseline)..(board::piece::k as usize + baseline) {
         for i in 0..cboard.piece_count[x] as usize{
@@ -297,7 +294,7 @@ pub fn generator(list : &mut movelist, cboard : &board::chessboard) {
                 6 => { // pawn
                     let mut dir : i8 = 10;
                     if baseline != 0 { dir = -10 };
-                    
+
                     // quiet moves
                     if cboard.layout[piece.wrapping_add(dir as u8) as usize]
                             == board::piece::Empty as u8 {
@@ -324,7 +321,7 @@ pub fn generator(list : &mut movelist, cboard : &board::chessboard) {
                                     board::piece::q as u8, false, false, false,0), list);
                                 add_move(_move::new(piece, piece.wrapping_add(dir as u8), 0,
                                     board::piece::r as u8, false, false, false,0), list);
-                                add_move(_move::new(piece, piece.wrapping_add(dir as u8), 0, 
+                                add_move(_move::new(piece, piece.wrapping_add(dir as u8), 0,
                                     board::piece::b as u8, false, false, false,0), list);
                                 add_move(_move::new(piece, piece.wrapping_add(dir as u8), 0,
                                     board::piece::n as u8, false, false, false,0), list);
@@ -339,8 +336,8 @@ pub fn generator(list : &mut movelist, cboard : &board::chessboard) {
                     }
 
                     // captures
-                    for y in 0..2 {
-                        let offset = around[y] + dir;
+                    for offs in &around[0..2] {
+                        let offset = offs + dir;
                         let target = cboard.layout[piece.wrapping_add(offset as u8) as usize];
                         // TODO this condition may be too computation-heavy
                         if target != board::void_square &&
@@ -361,7 +358,7 @@ pub fn generator(list : &mut movelist, cboard : &board::chessboard) {
                                     board::piece::q as u8, false, false, false, MVV[target as usize]), list);
                                 add_move(_move::new(piece, piece.wrapping_add(offset as u8), target,
                                     board::piece::r as u8, false, false, false, MVV[target as usize]), list);
-                                add_move(_move::new(piece, piece.wrapping_add(offset as u8), target, 
+                                add_move(_move::new(piece, piece.wrapping_add(offset as u8), target,
                                     board::piece::b as u8, false, false, false, MVV[target as usize]), list);
                                 add_move(_move::new(piece, piece.wrapping_add(offset as u8), target,
                                     board::piece::n as u8, false, false, false, MVV[target as usize]), list);

--- a/src/sanity.rs
+++ b/src/sanity.rs
@@ -44,9 +44,9 @@ fn hashing() {
     let first_hash = main_board.zobrist;
     fen::parse("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 40 32", &mut main_board);
     let second_hash = main_board.zobrist;
-    
+
     assert!(first_hash == second_hash);
-    
+
     fen::parse("8/p7/Pp1p1rk1/1Pp2N2/4P1K1/3P3P/8/8 b - - 0 53", &mut main_board);
     let third_hash = main_board.zobrist;
 
@@ -207,7 +207,7 @@ pub fn perft(depth : i32, cboard : &mut board::chessboard) {
 
     let mut move_list : moves::movelist =  moves::movelist::new();
     moves::generator(&mut move_list, cboard);
-   
+
     for x in 0..move_list.count as usize {
         if !movement::make(&move_list.all[x], cboard) {
             continue
@@ -219,22 +219,22 @@ pub fn perft(depth : i32, cboard : &mut board::chessboard) {
 
 pub fn perft_test(depth: i32, cboard : &mut board::chessboard) -> f64 {
     unsafe {
-    println!("Perft test to depth: {}", depth);
-    leafnodes = 0f64;
+        println!("Perft test to depth: {}", depth);
+        leafnodes = 0f64;
 
-    let mut move_list : moves::movelist =  moves::movelist::new();
-    moves::generator(&mut move_list, cboard);
+        let mut move_list : moves::movelist =  moves::movelist::new();
+        moves::generator(&mut move_list, cboard);
 
-    for x in 0..move_list.count as usize {
-        if !movement::make(&move_list.all[x], cboard) {
-            continue
+        for x in 0..move_list.count as usize {
+            if !movement::make(&move_list.all[x], cboard) {
+                continue
+            }
+            perft(depth - 1, cboard);
+            movement::undo(cboard);
         }
-        perft(depth - 1, cboard);
-        movement::undo(cboard);
-    }
 
-    println!("Test Complete: {} nodes", leafnodes);
-    return leafnodes
+        println!("Test Complete: {} nodes", leafnodes);
+        leafnodes
     }
 }
 

--- a/src/square.rs
+++ b/src/square.rs
@@ -13,36 +13,35 @@ pub fn attacked(target : u8, side : bool, cboard : &board::chessboard) -> bool {
     // attack by pawns
     if side == board::white {
         search = board::piece::P as u8;
-        for x in 2..4 {
-            if cboard.layout[(target as i8 + diagonal[x]) as usize] == search {
+        for d in &diagonal[2..] {
+            if cboard.layout[(target as i8 + d) as usize] == search {
                 return true;
             }
         }
     }
     else {
         search = board::piece::p as u8;
-        for x in 0..2 {
-            if cboard.layout[(target as i8 + diagonal[x]) as usize] == search {
+        for d in &diagonal[..2] {
+            if cboard.layout[(target as i8 + d) as usize] == search {
                 return true;
             }
         }
     }
 
     // attack by knights
-    if side == board::white {search = board::piece::N as u8;} 
-    else {search = board::piece::n as u8;}
-    for x in 0..8 {
-        if cboard.layout[(target as i8 + knight[x]) as usize] == search {
+    search = if side == board::white { board::piece::N } else { board::piece::n } as u8;
+    for k in &knight[..] {
+        if cboard.layout[(target as i8 + k) as usize] == search {
             return true;
         }
     }
 
     // attack by bishop or queen diagonally
-    if side == board::white {search = board::piece::B as u8; queen = board::piece::Q as u8;} 
+    if side == board::white {search = board::piece::B as u8; queen = board::piece::Q as u8;}
     else {search = board::piece::b as u8; queen = board::piece::q as u8;}
-    for x in 0..4 {
+    for d in &diagonal[..] {
         let mut current = target as usize;
-        current = (current as i8 + diagonal[x]) as usize;
+        current = (current as i8 + d) as usize;
         while cboard.layout[current] != board::void_square {
             if cboard.layout[current] == search || cboard.layout[current] == queen {
                 return true;
@@ -50,16 +49,16 @@ pub fn attacked(target : u8, side : bool, cboard : &board::chessboard) -> bool {
                 // blocking piece
                 break;
             }
-            current = (current as i8 + diagonal[x]) as usize;
+            current = (current as i8 + d) as usize;
         }
     }
 
     // attack by rook or cross queen
-    if side == board::white {search = board::piece::R as u8; queen = board::piece::Q as u8;} 
+    if side == board::white {search = board::piece::R as u8; queen = board::piece::Q as u8;}
     else {search = board::piece::r as u8; queen = board::piece::q as u8;}
-    for x in 0..4 {
+    for x in &cross[..] {
         let mut current = target as usize;
-        current = (current as i8 + cross[x]) as usize;
+        current = (current as i8 + x) as usize;
         while cboard.layout[current] != board::void_square {
             if cboard.layout[current] == search || cboard.layout[current] == queen {
                 return true;
@@ -67,21 +66,14 @@ pub fn attacked(target : u8, side : bool, cboard : &board::chessboard) -> bool {
                 // blocking piece
                 break;
             }
-            current = (current as i8 + cross[x]) as usize;
-        }
-    }
-    
-    // attack by king
-    if side == board::white {search = board::piece::K as u8;} 
-    else {search = board::piece::k as u8;}
-    for x in 0..8 {
-        if cboard.layout[(target as i8 + king[x]) as usize] == search {
-            return true;
+            current = (current as i8 + x) as usize;
         }
     }
 
-    // no attack found
-    false
+    // attack by king
+    if side == board::white {search = board::piece::K as u8;}
+    else {search = board::piece::k as u8;}
+    king[..].iter().any(|k| cboard.layout[(target as i8 + *k) as usize] == search)
 }
 
 pub fn clear (target : u8, cboard : &mut board::chessboard) {

--- a/src/think.rs
+++ b/src/think.rs
@@ -40,7 +40,7 @@ const white_pawn_piece_square : [i32; 120] =
     0,  0,  0,  0,  0,  0,  0,  0, 0,  0,
     0, 0,  0,  0,  0,  0,  0,  0,  0,  0];
 
-const black_knight_piece_square : [i32; 120] = 
+const black_knight_piece_square : [i32; 120] =
    [0, 0,  0,  0,  0,  0,  0,  0,  0,  0,
     0,  0,  0,  0,  0,  0,  0,  0, 0,  0,
     0, -50,-40,-30,-30,-30,-30,-40,-50, 0,
@@ -54,7 +54,7 @@ const black_knight_piece_square : [i32; 120] =
     0,  0,  0,  0,  0,  0,  0,  0, 0, 0,
     0,  0,  0,  0,  0,  0,  0,  0, 0, 0];
 
-const white_knight_piece_square : [i32; 120] = 
+const white_knight_piece_square : [i32; 120] =
     [0,  0,  0,  0,  0,  0,  0,  0, 0, 0,
     0,  0,  0,  0,  0,  0,  0,  0, 0, 0,
     0, -50,-40,-30,-30,-30,-30,-40,-50, 0,
@@ -139,7 +139,7 @@ impl transposition {
 }
 
 pub struct transposition_table {
-    pub entries: Vec<transposition> 
+    pub entries: Vec<transposition>
 }
 
 impl transposition_table {
@@ -168,9 +168,9 @@ pub fn find_transposition(cboard: &board::chessboard) -> u32 {
     // TODO collisions here should be astronomically rare
     // but is this really the case?
     if cboard.zobrist == cboard.transposition_table.entries[i].hash {
-        return cboard.transposition_table.entries[i].move_
+        cboard.transposition_table.entries[i].move_
     } else {
-        return 0
+        0
     }
 }
 
@@ -192,7 +192,7 @@ fn evaluate (cboard: &board::chessboard) -> i32 {
         let loc = cboard.piece_list[board::piece::P as usize][x];
         score += white_pawn_piece_square[loc as usize];
     }
-   
+
     for x in 0..cboard.piece_count[board::piece::p as usize] as usize{
         let loc = cboard.piece_list[board::piece::p as usize][x];
         score -= black_pawn_piece_square[loc as usize];
@@ -229,9 +229,9 @@ fn evaluate (cboard: &board::chessboard) -> i32 {
     }
 
     if cboard.side == board::white {
-        return score
+        score
     } else {
-        return -score
+        -score
     }
 }
 
@@ -259,23 +259,23 @@ pub fn start(cboard: &mut board::chessboard, depth_target: u8, think_time:i64) {
 
     unsafe {
         for depth in 1..target+1 {
-	    let mut node : u64 = 0;
-	    score = alpha_beta(-inf, inf, depth, cboard, &mut node, end);
-	    if node != 0 && time_up == false {
-	        print!("info depth {} score cp {} nodes {}", depth, score, node);
-	        print_pv(cboard, depth as usize);
-	        print!("\n");
+            let mut node : u64 = 0;
+            score = alpha_beta(-inf, inf, depth, cboard, &mut node, end);
+            if node != 0 && !time_up {
+                print!("info depth {} score cp {} nodes {}", depth, score, node);
+                print_pv(cboard, depth as usize);
+                println!();
                 bestmove = moves::_move{container: find_transposition(cboard), score:0};
-	    }
+            }
         }
     }
 
     print!("bestmove ");
     let move_ = moves::to_AN(&bestmove);
-    for x in 0..5 {
-        print!("{}",move_[x]);
+    for m in &move_[0..5] {
+        print!("{}", m);
     }
-    print!("\n");
+    println!();
 
 }
 
@@ -332,7 +332,7 @@ fn alpha_beta(alpha: i32, beta: i32, depth: u8, cboard: &mut board::chessboard, 
 
         *node += 1;
 
-        if illegal == true {
+        if illegal {
             illegal = false;
         }
 
@@ -351,27 +351,27 @@ fn alpha_beta(alpha: i32, beta: i32, depth: u8, cboard: &mut board::chessboard, 
     if illegal {
         // checkmate
         if cboard.side == board::white {
-            if square::attacked(cboard.piece_list[board::piece::K as usize][0], board::black, cboard) {
-                return -board::piece_value[1] as i32 + cboard.ply as i32;
+            return if square::attacked(cboard.piece_list[board::piece::K as usize][0], board::black, cboard) {
+                -board::piece_value[1] as i32 + cboard.ply as i32
             } else {
                 // stalemate
-                return 0
-            }
+                0
+            };
         } else {
-            if square::attacked(cboard.piece_list[board::piece::k as usize][0], board::white, cboard) {
-                return -board::piece_value[1] as i32 + cboard.ply as i32;
+            return if square::attacked(cboard.piece_list[board::piece::k as usize][0], board::white, cboard) {
+                -board::piece_value[1] as i32 + cboard.ply as i32
             } else {
                 // stalemate
-                return 0
-            }
+                0
+            };
         }
     }
 
     if stale_alpha != new_alpha {
         store_transposition(move_, cboard);
     }
-    
-    return new_alpha
+
+    new_alpha
 }
 
 fn quiescence(alpha: i32, beta: i32, cboard: &mut board::chessboard) -> i32 {
@@ -388,7 +388,7 @@ fn quiescence(alpha: i32, beta: i32, cboard: &mut board::chessboard) -> i32 {
     let mut new_alpha = alpha;
     let stale_alpha = alpha;
     let mut illegal = true;
-    let mut move_ = 0;
+    let mut _move = 0;
     let mut score = -inf;
 
     if eval >= beta {
@@ -410,7 +410,7 @@ fn quiescence(alpha: i32, beta: i32, cboard: &mut board::chessboard) -> i32 {
                 continue
             }
 
-            if illegal == true {
+            if illegal {
                 illegal = false;
             }
 
@@ -422,12 +422,12 @@ fn quiescence(alpha: i32, beta: i32, cboard: &mut board::chessboard) -> i32 {
                     return beta
                 }
                 new_alpha = score;
-                move_ = move_list.all[index].container;
+                _move = move_list.all[index].container;
             }
         }
     }
 
-    return new_alpha
+    new_alpha
 }
 
 fn optimize_mvv_lva(index : usize, list : &mut moves::movelist) {
@@ -457,8 +457,8 @@ fn print_pv(cboard : &mut board::chessboard, depth : usize) {
         if find_transposition(cboard) != 0 {
             let bestmove = moves::_move{container: find_transposition(cboard), score:0};
             let move_ = moves::to_AN(&bestmove);
-            for x in 0..5 {
-                print!("{}",move_[x]);
+            for m in &move_[0..5] {
+                print!("{}", m);
             }
             print!(" ");
             movement::make(&bestmove, cboard);

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -2,14 +2,14 @@ use board;
 use fen;
 
 pub fn looping(cboard : &mut board::chessboard) {
-    use std::io::{self,BufRead};
+    use std::io;
 
-    let mut stdin = io::stdin();
+    let stdin = io::stdin();
     let mut input = &mut String::new();
 
     loop {
         input.clear();
-        stdin.read_line(input);
+        stdin.read_line(input).unwrap();
 
 
         if input == "" || input == "\n" {
@@ -19,16 +19,16 @@ pub fn looping(cboard : &mut board::chessboard) {
             startup_info();
         }
         else if input == "isready\n" {
-            print!("readyok\n");
+            println!("readyok");
         }
         else if input.split_whitespace().any(|x| x == "ucinewgame") {
             new_game(cboard);
         }
         else if input.split_whitespace().any(|x| x == "position") {
-            parse_position(&input, cboard);
+            parse_position(input, cboard);
         }
         else if input.split_whitespace().any(|x| x == "go") {
-            parse_search(&input, cboard);
+            parse_search(input, cboard);
         }
         else if input.split_whitespace().any(|x| x == "quit") {
             break
@@ -37,13 +37,13 @@ pub fn looping(cboard : &mut board::chessboard) {
 }
 
 fn startup_info() {
-    print!("id name Cicada\n");
-    print!("id author Kayali\n");
-    print!("uciok\n");
+    println!("id name Cicada");
+    println!("id author Kayali");
+    println!("uciok");
 }
 
 fn new_game(cboard : &mut board::chessboard) {
-    fen::parse(&"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1", cboard);
+    fen::parse("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1", cboard);
     // TODO clear transposition table!
 }
 
@@ -51,15 +51,10 @@ fn parse_position(input : &str, cboard : &mut board::chessboard) {
     let v: Vec<&str> = input.split_whitespace().collect();
 
     if v[1] == "startpos" {
-        fen::parse(&"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1", cboard);
+        fen::parse("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1", cboard);
         parse_moves(&v, 2, cboard);
     } else if v[1] == "fen" {
-        let mut fen_code = v[2].to_string();
-
-        for x in 3..8 {
-            fen_code = fen_code + " "+ &v[x];
-        }
-
+        let fen_code = v[2..8].join(" ");
         fen::parse(&fen_code, cboard);
         parse_moves(&v, 8, cboard);
     }
@@ -67,15 +62,15 @@ fn parse_position(input : &str, cboard : &mut board::chessboard) {
     board::print(cboard);
 }
 
-fn parse_moves(input : &Vec<&str>, input_index : usize, cboard : &mut board::chessboard) {
+fn parse_moves(input : &[&str], input_index : usize, cboard : &mut board::chessboard) {
     use moves;
     use movement;
 
-    for index in input_index + 1..input.len() {
-        let move_str = input[index].as_bytes();
-        let mut move_ = moves::from_AN(move_str, cboard);
-
-        assert!(movement::make(&move_, cboard));
+    for move_str in &input[input_index + 1..] {
+        let move_bytes = move_str.as_bytes();
+        let move_ = moves::from_AN(move_bytes, cboard);
+        let success = movement::make(&move_, cboard);
+        assert!(success);
     }
 }
 
@@ -86,28 +81,17 @@ fn parse_search(input : &str, cboard : &mut board::chessboard) {
     let mut time = 0;
     let mut depth = 0;
 
-    if cboard.side == board::white {
-        for x in 0..v.len() {
-            if v[x] == "wtime" {
-                time = v[x + 1].parse::<i64>().unwrap();
-            }
-        }
-    } else {
-        for x in 0..v.len() {
-            if v[x] == "btime" {
-                time = v[x + 1].parse::<i64>().unwrap();
-            }
-        }
+    let time_mark = if cboard.side == board::white { "wtime" } else { "btime" };
+    if let Some(i) = v.iter().position(|s| *s == time_mark) {
+        time = v[i + 1].parse::<i64>().unwrap();
     }
 
-    for x in 0..v.len() {
-        if v[x] == "depth" {
-            depth = v[x + 1].parse::<u8>().unwrap();
-        }
+    if let Some(i) = v.iter().position(|s| *s == "depth") {
+        depth = v[i + 1].parse::<u8>().unwrap();
     }
 
     println!("time: {}, depth: {}", time, depth);
     if time != 0 || depth != 0 {
-        think::start(cboard, depth, time); 
+        think::start(cboard, depth, time);
     }
 }

--- a/src/zobrist.rs
+++ b/src/zobrist.rs
@@ -10,27 +10,18 @@ pub fn init() {
     use rand::{thread_rng, Rng};
     let mut rng = thread_rng();
 
-    for x in 0..13 {
-        for i in 0..board::full_board_size {
-            unsafe {
-                zobrist[x][i] = rng.gen();
+    unsafe {
+        for mut r in &mut zobrist[..] {
+            for mut b in &mut r[..] {
+                *b = rng.gen();
             }
         }
-    }
-
-    for x in 0..16 {
-        unsafe {
-            castling[x] = rng.gen();
+        for mut c in &mut castling[..] {
+            *c = rng.gen();
         }
-    }
-
-    for x in 0..8 {
-        unsafe {
-            EP[x] = rng.gen();
+        for mut e in &mut EP {
+            *e = rng.gen();
         }
-    }
-
-    unsafe {
         side = rng.gen();
     }
 }
@@ -59,11 +50,11 @@ pub fn hash(sboard: &board::chessboard) -> u64 {
     if sboard.en_passant != board::void_square {
         unsafe {
             // mod 10 to find file
-            hash ^= EP[(sboard.en_passant % 10) as usize - 1]; 
+            hash ^= EP[(sboard.en_passant % 10) as usize - 1];
         }
     }
-    
-    return hash;
+
+    hash
 }
 
 pub fn hash_square(target : u8, cboard: &mut board::chessboard) {
@@ -84,7 +75,7 @@ pub fn en_passant(cboard: &mut board::chessboard) {
     if cboard.en_passant != board::void_square {
         unsafe {
             // mod 10 to find file
-            cboard.zobrist ^= EP[(cboard.en_passant % 10) as usize - 1]; 
+            cboard.zobrist ^= EP[(cboard.en_passant % 10) as usize - 1];
         }
     }
 }


### PR DESCRIPTION
It's a good idea to set your editor to remove trailing spaces, and layout code using either all tabs or spaces (I personally prefer 4 spaces, and so does rustfmt by default).

The clippy-induced changes are mostly trivial, but I removed two loops in uci.rs, using `.iter().position(..)` instead.