### PR TITLE
only parse moves when position command line has at least three segments

### DIFF
--- a/src/uci.rs
+++ b/src/uci.rs
@@ -52,7 +52,9 @@ fn parse_position(input : &str, cboard : &mut board::chessboard) {
 
     if v[1] == "startpos" {
         fen::parse("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1", cboard);
-        parse_moves(&v, 2, cboard);
+        if v.len() > 2 {
+            parse_moves(&v, 2, cboard);
+        }
     } else if v[1] == "fen" {
         let fen_code = v[2..8].join(" ");
         fen::parse(&fen_code, cboard);


### PR DESCRIPTION
Previously, we assumed that we would only get a startpos command containing
moves played, like `position startpos e2e3`. This seems to be good enough for
some UCI drivers (including XBoard), but others (at least Cute Chess) will also
issue a `position startpos` with no moves at the beginning of the game (even if
Cicada is playing black).

Resolves #3.